### PR TITLE
Feature/fix load spotflow guard

### DIFF
--- a/lib/composables/useSpotflowPayment.ts
+++ b/lib/composables/useSpotflowPayment.ts
@@ -7,7 +7,6 @@ declare global {
   }
 }
 
-
 let libraryPromise: Promise<any> | null = null
 
 export function useSpotflowPayment() {
@@ -37,17 +36,21 @@ export function useSpotflowPayment() {
       }
 
       const startTime = Date.now()
-      
+
       const checkInterval = setInterval(() => {
         if (window.SpotflowCheckout) {
           clearInterval(checkInterval)
           resolve(window.SpotflowCheckout)
         } else if (Date.now() - startTime > timeout) {
           clearInterval(checkInterval)
-          reject(new Error(
-            'SpotflowCheckout SDK not loaded after ' + timeout + 'ms. ' +
-            'Ensure the CDN script is in your HTML.'
-          ))
+          reject(
+            new Error(
+              'SpotflowCheckout SDK not loaded after ' +
+                timeout +
+                'ms. ' +
+                'Ensure the CDN script is in your HTML.'
+            )
+          )
         }
       }, 50) // Check every 50ms
     })
@@ -55,13 +58,12 @@ export function useSpotflowPayment() {
     return libraryPromise
   }
   const loadSpotflow = async (options: SpotflowPaymentOptions) => {
-    const cdnUrl: string = 'https://v2.inline-checkout.spotflow.one/dist/checkout-inline.js'
-    await loadCdnScript(cdnUrl)
-
-    if (typeof window === 'undefined') {
-      throw new Error('SpotflowCheckout is not available in the window object')
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      throw new Error('SpotflowCheckout is only available in the browser')
     }
 
+    const cdnUrl: string = 'https://v2.inline-checkout.spotflow.one/dist/checkout-inline.js'
+    await loadCdnScript(cdnUrl)
     await waitForLibrary()
 
     try {


### PR DESCRIPTION
# What does this PR do?

In useSpotflowPayment.ts (specifically loadSpotflow function), the loadCdnScript tries to access the document. When it runs during server-side rendering (Vite SSR, tests), it will throw an error before it hits typeof window === 'undefined'.

## Description of Task to be completed?

Rearrange the window check so that the helpers (loadCdnScript, waitForLibrary) don't run during server-side rendering unless there is a window.

## How should this be manually tested?

This change doesn't affect anything in the UI, but it can be tested on the server side with a test:

1. `yarn add -D vitest @vue/test-utils`
2. create **lib/composables/useSpotflowPayment.spec.ts**:

> import { describe, it, expect } from 'vitest'
> import { useSpotflowPayment } from './useSpotflowPayment'
> 
> describe('useSpotflowPayment', () => {
>   it('throws a browser-only error when window is missing', async () => {
>     const load = useSpotflowPayment()
>     await expect(load({} as any)).rejects.toThrow(/browser/i)
>   })
> })
3. The test should pass and acknowledge the error `SpotflowCheckout is only available in the browser`

## Screenshots/Screen records (if appropriate)
<img width="964" height="244" alt="Screenshot 2025-10-17 at 12 07 17 PM" src="https://github.com/user-attachments/assets/29952743-95c5-484f-96b9-1e7406674f28" />

With the new change, the test passes and shows the expected error.
___________________________________________________________________________________________________________
<img width="953" height="442" alt="Screenshot 2025-10-17 at 12 07 45 PM" src="https://github.com/user-attachments/assets/39eec25d-bcd4-414a-8efa-b1afa5083d6c" />

With the old code, the `loadCdnScript` is accessed with no document, so it displays a `document is not defined` error. 

## Link to Issue

[#26 .](https://github.com/Spotflow-One/vue-spotflow-checkout/issues/26)

## Add Hacktoberfest Accepted Label to Your PR

Add "hacktoberfest-accepted" label to your created PR

## Any background context you want to provide?

Users in the browser see the same behavior. The guard only triggers when window or document is missing (SSR, tests, Node). In the browser those globals exist, so the code keeps executing, the SDK still loads, and the UI stays unchanged.
